### PR TITLE
Fix logo loading for packaged executable

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -10,6 +10,16 @@ from pathlib import Path
 from tkinter import ttk
 from tkinter import scrolledtext, filedialog  # pour la fenêtre Explications
 
+
+def resource_path(relative: str) -> Path:
+    """Retourne le chemin absolu d'une ressource en mode IDE ou PyInstaller."""
+
+    if hasattr(sys, "_MEIPASS") and getattr(sys, "_MEIPASS"):
+        base_path = Path(getattr(sys, "_MEIPASS"))
+    else:
+        base_path = Path(__file__).resolve().parent
+    return base_path / relative
+
 # ---- numpy pour l'algèbre ----
 try:
     import numpy as np
@@ -794,12 +804,12 @@ class FourApp(tk.Tk):
 
 
     def _load_logo(self):
-        path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "rochias.png")
-        if not os.path.exists(path):
+        path = resource_path("rochias.png")
+        if not path.exists():
             return
 
         try:
-            img = tk.PhotoImage(file=path)
+            img = tk.PhotoImage(file=str(path))
         except tk.TclError:
             return
 


### PR DESCRIPTION
## Summary
- add a resource helper that resolves asset paths both in the IDE and inside a packaged executable
- load the application logo through the resource helper so it remains visible after freezing

## Testing
- python -m py_compile Main.py

------
https://chatgpt.com/codex/tasks/task_e_68cc7ee53a34832ea651e3b3b2588f4e