### PR TITLE
Ensure packaged executable bundles image asset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build executable
         run: |
-          pyinstaller --noconfirm --windowed --onefile --name FourTapis Main.py
+          pyinstaller --noconfirm --windowed --onefile --name FourTapis --add-data "rochias.png;." Main.py
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- update the Windows build workflow to bundle the PNG asset with the PyInstaller executable

## Testing
- python -m py_compile Main.py

------
https://chatgpt.com/codex/tasks/task_e_68cc8b0cd050832ea1f7294643d68e74