### PR TITLE
Fix PyInstaller asset path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build executable
         run: |
-          pyinstaller --noconfirm --windowed --onefile --name FourTapis --add-data "rochias.png;." Main.py
+          pyinstaller --noconfirm --windowed --onefile --name FourTapis --add-data "rochias_four/rochias.png;rochias_four" Main.py
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- ensure the workflow bundles the PNG asset from its new location inside the package

## Testing
- python -m py_compile Main.py rochias_four/*.py

------
https://chatgpt.com/codex/tasks/task_e_68cf92efdc58832eb78d9d16e7228a39