### PR TITLE
Add safe synergy total and update UI label

### DIFF
--- a/rochias_four/app.py
+++ b/rochias_four/app.py
@@ -613,7 +613,7 @@ class FourApp(tk.Tk):
         badge_box = ttk.Frame(hero, style="CardInner.TFrame")
         badge_box.grid(row=0, column=2, sticky="e", padx=(12, 0))
         ttk.Label(badge_box, text="Mode temps réel", style="BadgeReady.TLabel").pack(side="left", padx=(0, 8))
-        ttk.Label(badge_box, text="Interpolation 12 points", style="BadgeNeutral.TLabel").pack(side="left")
+        ttk.Label(badge_box, text="Modèle synergie (calibré)", style="BadgeNeutral.TLabel").pack(side="left")
         self.density_button = ttk.Button(
             badge_box,
             text="Mode compact",

--- a/rochias_four/calculations.py
+++ b/rochias_four/calculations.py
@@ -16,6 +16,7 @@ from .calibration import (
     is_monotone_decreasing_in_each_f,
     split_contributions,
     total_time_minutes,
+    total_time_minutes_safe,
 )
 
 
@@ -65,7 +66,7 @@ def compute_simulation_plan(f1: float, f2: float, f3: float) -> CalculationResul
         anchor_model_total, f1, f2, f3, split="anchor", anch=DEFAULT_ANCHOR
     )
 
-    total_synergy = total_time_minutes(f1, f2, f3, model="synergy", syn=DEFAULT_SYNERGY)
+    total_synergy = total_time_minutes_safe(f1, f2, f3, syn=DEFAULT_SYNERGY)
     synergy_split_model = split_contributions(
         total_synergy, f1, f2, f3, split="anchor", anch=DEFAULT_ANCHOR
     )


### PR DESCRIPTION
## Summary
- add a safeguarded synergy total helper that enforces monotony at low frequencies and use it where the app consumes synergy totals
- expose the safe helper through the calibration API for downstream modules
- clarify the dashboard badge by renaming it to “Modèle synergie (calibré)”

## Testing
- python -m py_compile Main.py rochias_four/*.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c79e1a40832eb55c806c7bf63841