### PR TITLE
Replace product curve plot with oven segment widget

### DIFF
--- a/rochias_four/app.py
+++ b/rochias_four/app.py
@@ -58,7 +58,7 @@ from .timeline import FeedTimeline
 from .geometry import build_line_geometry
 from .graphbar import GraphBar
 from .details_window import DetailsWindow
-from .ui.product_curve import ProductCurveWidget
+from .ui.oven_curve import OvenCurveWidget
 from .ui.theming import theme as current_plot_theme
 
 
@@ -113,11 +113,8 @@ class FourApp(tk.Tk):
         self.logo_img = None
         self._error_after = None
         self.graph_bars: list[GraphBar] = []
-        self.product_curve_widget: ProductCurveWidget | None = None
-        self.product_curve_sections: list[dict] = []
-        self.product_curve_lengths: list[float] = []
-        self.product_curve_thicknesses: list[float] = []
-        self.product_curve_total_length = 0.0
+        self.product_curve_widget: OvenCurveWidget | None = None
+        self._curve_last_tick: float | None = None
         self._load_logo()
         self._build_ui()
         load_anchor_from_disk()
@@ -278,23 +275,6 @@ class FourApp(tk.Tk):
                 graph.update(t_now_min, self.feed_timeline)
             except Exception:
                 pass
-        if not self.animating:
-            self._update_product_curve()
-
-    def _update_product_curve(self, head_x: float | None = None):
-        if not self.product_curve_widget:
-            return
-        if not self.product_curve_lengths or not self.product_curve_thicknesses:
-            self.product_curve_widget.update(0.0, [1.0], [0.0], y_max_cm=DISPLAY_Y_MAX_CM)
-            return
-        target = self.product_curve_total_length if self.product_curve_total_length > 0 else sum(self.product_curve_lengths)
-        head = max(0.0, min(head_x if head_x is not None else 0.0, target))
-        self.product_curve_widget.update(
-            head,
-            self.product_curve_lengths,
-            self.product_curve_thicknesses,
-            y_max_cm=DISPLAY_Y_MAX_CM,
-        )
 
     def _normalized_weights(self, profile, count: int) -> list[float]:
         if count <= 0:
@@ -318,7 +298,6 @@ class FourApp(tk.Tk):
     ) -> None:
         sections: list[dict] = []
         lengths: list[float] = []
-        thicknesses: list[float] = []
 
         def _add_cells(cells: list[int], belt_index: int, h_start: float, h_end: float, profile) -> None:
             if not cells:
@@ -344,63 +323,29 @@ class FourApp(tk.Tk):
                     }
                 )
                 lengths.append(length_m)
-                thicknesses.append(cell_height)
 
         _add_cells(cells_belt1, 0, h1_cm, h1_cm, [1.0] * len(cells_belt1))
         _add_cells(cells_belt2, 1, h1_cm, h2_cm, CELL_PROFILE_2)
         _add_cells(cells_belt3, 2, h2_cm, h3_cm, CELL_PROFILE_3)
 
         cleaned_sections: list[dict] = []
-        cleaned_lengths: list[float] = []
-        cleaned_thicknesses: list[float] = []
-        for sec, length, thick in zip(sections, lengths, thicknesses):
+        for sec, length in zip(sections, lengths):
             if length <= 0.0:
                 continue
             cleaned_sections.append(sec)
-            cleaned_lengths.append(length)
-            cleaned_thicknesses.append(thick)
 
-        if cleaned_sections:
-            self.product_curve_sections = cleaned_sections
-            self.product_curve_lengths = cleaned_lengths
-            self.product_curve_thicknesses = cleaned_thicknesses
-            self.product_curve_total_length = sum(cleaned_lengths)
-            if self.product_curve_widget:
-                self.product_curve_widget.set_total_length(self.product_curve_total_length)
-        else:
-            self.product_curve_sections = []
-            self.product_curve_lengths = []
-            self.product_curve_thicknesses = []
-            self.product_curve_total_length = 0.0
-            if self.product_curve_widget:
-                self.product_curve_widget.set_total_length(1.0)
-        self._update_product_curve(0.0)
+        if self.product_curve_widget:
+            self.product_curve_widget.set_geometry(cleaned_sections)
+        self._curve_last_tick = None
 
-    def _current_head_position(self, seg_index: int, elapsed_in_seg: float) -> float:
-        if not self.product_curve_sections:
-            return 0.0
-        head = 0.0
-        remaining = float(max(0.0, elapsed_in_seg))
-        for sec in self.product_curve_sections:
-            belt_idx = int(sec.get("belt_index", 0))
-            length = float(sec.get("length", 0.0))
-            duration = float(sec.get("duration", 0.0))
-            if belt_idx < seg_index:
-                head += max(0.0, length)
-                continue
-            if belt_idx > seg_index:
-                break
-            if duration <= 0.0:
-                head += max(0.0, length)
-                continue
-            if remaining <= 0.0:
-                break
-            frac = max(0.0, min(1.0, remaining / duration))
-            head += max(0.0, length) * frac
-            remaining -= duration
-            if remaining <= 0.0:
-                break
-        return min(head, self.product_curve_total_length)
+    def _update_curve_speeds(self) -> None:
+        if not self.product_curve_widget:
+            return
+        speeds_mps = [max(0.0, float(val)) * SPEED_M_PER_S_PER_HZ for val in self.seg_speeds]
+        try:
+            self.product_curve_widget.set_speeds(speeds_mps)
+        except Exception:
+            pass
     def _sync_theme_attributes(self):
         palette = getattr(self, "_palette", {})
         for key, value in palette.items():
@@ -852,7 +797,7 @@ class FourApp(tk.Tk):
         self.bars_heading_label = ttk.Label(pcard, text="Barres de chargement — Référence maintenance (L/v)", style="CardHeading.TLabel")
         self.bars_heading_label.pack(anchor="w", pady=(0, 12))
         ttk.Label(pcard, text="Courbe de couche produit (temps réel)", style="Card.TLabel").pack(anchor="w")
-        self.product_curve_widget = ProductCurveWidget(pcard, total_length_m=1.0, y_max_cm=DISPLAY_Y_MAX_CM)
+        self.product_curve_widget = OvenCurveWidget(pcard, y_max_cm=DISPLAY_Y_MAX_CM)
         self.theme.register_axes(self.product_curve_widget.ax)
         self.product_curve_widget.pack(fill="x", expand=False, pady=(6, 12))
         self.bars = []
@@ -1106,10 +1051,14 @@ class FourApp(tk.Tk):
         self.btn_pause.config(state="disabled", text="⏸ Pause")
         self.btn_calculer.config(state="normal")
         self._update_graphs(0.0)
-        self._update_product_curve(0.0)
+        if self.product_curve_widget:
+            self.product_curve_widget.reset_segments()
+            self.product_curve_widget.set_feeding(False)
+        self._curve_last_tick = None
         self.seg_durations = [0.0, 0.0, 0.0]
         self.seg_distances = [0.0, 0.0, 0.0]
         self.seg_speeds = [0.0, 0.0, 0.0]
+        self._update_curve_speeds()
         self.total_duration = 0.0
         self.notified_stage1 = False
         self.notified_stage2 = False
@@ -1244,6 +1193,7 @@ class FourApp(tk.Tk):
         freq_display = (float(result.f1_hz), float(result.f2_hz), float(result.f3_hz))
         self.seg_distances = [0.0, 0.0, 0.0]
         self.seg_speeds = [float(val) for val in freq_display]
+        self._update_curve_speeds()
         self.seg_durations = [value * 60.0 for value in parts_minutes]
         self.total_duration = float(result.total_s)
         self.notified_stage1 = False
@@ -1361,6 +1311,10 @@ class FourApp(tk.Tk):
                 pass
         self._apply_graph_geometry(seg_times, th["h1_cm"], th["h2_cm"], th["h3_cm"])
         self._build_product_curve_data(seg_times, th["h1_cm"], th["h2_cm"], th["h3_cm"], cells_belt1, cells_belt2, cells_belt3)
+        if self.product_curve_widget:
+            self.product_curve_widget.reset_segments()
+            self.product_curve_widget.set_feeding(False)
+        self._curve_last_tick = None
         def _badge_style(pct: float) -> str:
             if pct > 0.5:
                 return "BadgeActive.TLabel"
@@ -1422,6 +1376,10 @@ class FourApp(tk.Tk):
         self.paused = False
         self.seg_idx = 0
         self.seg_start = time.perf_counter()
+        if self.product_curve_widget:
+            self.product_curve_widget.reset_segments()
+            self.product_curve_widget.set_feeding(True)
+        self._curve_last_tick = self.seg_start
         self.total_duration = sum(self.seg_durations)
         self.notified_stage1 = False
         self.notified_stage2 = False
@@ -1471,12 +1429,14 @@ class FourApp(tk.Tk):
             self._cancel_after()
             self.btn_pause.config(text="▶ Reprendre")
             self._set_stage_status(self.seg_idx, "pause")
+            self._curve_last_tick = None
         else:
             delta = time.perf_counter() - self.pause_t0
             self.seg_start += delta
             self.paused = False
             self.btn_pause.config(text="⏸ Pause")
             self._set_stage_status(self.seg_idx, "active")
+            self._curve_last_tick = time.perf_counter()
             self._tick()
 
     def _sim_minutes(self) -> float:
@@ -1500,6 +1460,8 @@ class FourApp(tk.Tk):
         self.btn_feed_stop.config(state="disabled")
         self.btn_feed_resume.config(state="normal")
         self.toast("Arrêt alimentation enregistré")
+        if self.product_curve_widget:
+            self.product_curve_widget.set_feeding(False)
         self._update_graphs(tnow)
 
     def on_feed_resume(self):
@@ -1517,6 +1479,8 @@ class FourApp(tk.Tk):
         self.btn_feed_stop.config(state="normal")
         self.btn_feed_resume.config(state="disabled")
         self.toast("Reprise alimentation enregistrée")
+        if self.product_curve_widget:
+            self.product_curve_widget.set_feeding(True)
         self._update_graphs(tnow)
 
     def _tick(self):
@@ -1526,13 +1490,24 @@ class FourApp(tk.Tk):
         dur = max(1e-6, self.seg_durations[i])
         vitesse = self.seg_speeds[i]
         now = time.perf_counter()
+        if self.product_curve_widget:
+            if self._curve_last_tick is None:
+                self._curve_last_tick = now
+            else:
+                dt = max(0.0, now - self._curve_last_tick)
+                if dt > 0.0:
+                    try:
+                        self.product_curve_widget.tick(dt)
+                    except Exception:
+                        pass
+                self._curve_last_tick = now
+        else:
+            self._curve_last_tick = now
         elapsed_raw = now - self.seg_start
         elapsed = max(0.0, elapsed_raw)
         clamped_elapsed = min(elapsed, dur)
         t_now_min = (sum(self.seg_durations[: self.seg_idx]) + clamped_elapsed) / 60.0
         self._update_graphs(t_now_min)
-        head_pos = self._current_head_position(self.seg_idx, clamped_elapsed)
-        self._update_product_curve(head_pos)
         remaining_current = max(0.0, dur - elapsed)
         remaining_future = sum(self.seg_durations[j] for j in range(i + 1, 3))
         total_remaining = max(0.0, remaining_current + remaining_future)
@@ -1559,9 +1534,12 @@ class FourApp(tk.Tk):
                 self.feed_on = True
                 self.btn_feed_stop.config(state="disabled")
                 self.btn_feed_resume.config(state="disabled")
-                self._update_product_curve(self.product_curve_total_length)
+                if self.product_curve_widget:
+                    self.product_curve_widget.set_feeding(False)
+                self._curve_last_tick = None
                 return
             self.seg_start = now
+            self._curve_last_tick = now
             j = self.seg_idx
             vitesse_j = self.seg_speeds[j]
             duree_j = self.seg_durations[j]
@@ -1570,7 +1548,6 @@ class FourApp(tk.Tk):
             self._set_stage_status(j, "active")
             if j + 1 < 3:
                 self._set_stage_status(j + 1, "ready")
-            self._update_product_curve(self._current_head_position(self.seg_idx, 0.0))
             self._schedule_tick()
             return
         pct = max(0.0, min(1.0, clamped_elapsed / dur)) * 100.0

--- a/rochias_four/ui/oven_curve.py
+++ b/rochias_four/ui/oven_curve.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import bisect
+from typing import Iterable, List, Sequence
+
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.figure import Figure
+
+from .theming import theme
+
+
+class OvenCurveWidget:
+    """Widget matplotlib affichant la courbe d'occupation du four.
+
+    La géométrie (longueur/épaisseur par cellule) est fournie via :meth:`set_geometry`.
+    La courbe garde en mémoire des segments occupés (liste d'intervalles [x₀, x₁]) et
+    applique des mises à jour incrémentales sur chaque tick : translation suivant les
+    vitesses réelles, ajout d'un tronçon d'entrée lorsque l'alimentation est active,
+    suppression automatique des morceaux sortis du four et fusion des segments contigus.
+    """
+
+    def __init__(self, parent, y_max_cm: float = 10.0):
+        self.y_max_cm = float(y_max_cm)
+        self.total_length = 0.0
+        self.sections: List[dict] = []
+        self._cell_starts: List[float] = []
+        self._cell_ends: List[float] = []
+        self._cell_thickness: List[float] = []
+        self._cell_belts: List[int] = []
+        self.segments: List[dict] = []
+        self.belt_speeds: dict[int, float] = {}
+        self.feeding = False
+        self._epsilon = 1e-6
+
+        self.fig = Figure(figsize=(7.5, 1.6), dpi=100)
+        self.ax = self.fig.add_subplot(111)
+        self._configure_axes()
+
+        t = theme()
+        (self._line,) = self.ax.plot([], [], lw=2, color=t.curve, drawstyle="steps-post", zorder=3)
+        self._fills: List = []
+        self.ax._product_line = self._line
+        self.ax._product_fill = None
+
+        self.canvas = FigureCanvasTkAgg(self.fig, master=parent)
+        self.widget = self.canvas.get_tk_widget()
+
+        self.set_geometry([])
+        self.reset_segments(draw=False)
+
+    # Tk proxy helpers -------------------------------------------------
+    def pack(self, **kwargs):  # pragma: no cover - Tk binding
+        self.widget.pack(**kwargs)
+
+    def grid(self, **grid_kw):  # pragma: no cover
+        self.widget.grid(**grid_kw)
+
+    def place(self, **kwargs):  # pragma: no cover
+        self.widget.place(**kwargs)
+
+    # Configuration ----------------------------------------------------
+    def _configure_axes(self) -> None:
+        t = theme()
+        self.ax.set_facecolor(t.surface)
+        for spine in self.ax.spines.values():
+            spine.set_color(t.stroke)
+        self.ax.grid(True, color=t.grid, alpha=0.35)
+        self.ax.set_xlim(0.0, 1.0)
+        self.ax.set_ylim(0.0, self.y_max_cm)
+        self.ax.set_xlabel("")
+        self.ax.set_ylabel("")
+        self.ax.tick_params(axis="x", labelsize=8)
+        self.ax.tick_params(axis="y", labelsize=8)
+
+    def set_y_max(self, y_max_cm: float) -> None:
+        if y_max_cm and y_max_cm > 0:
+            self.y_max_cm = float(y_max_cm)
+            self.ax.set_ylim(0.0, self.y_max_cm)
+            self.canvas.draw_idle()
+
+    def set_geometry(self, sections: Sequence[dict] | None) -> None:
+        self.sections = []
+        self._cell_starts = []
+        self._cell_ends = []
+        self._cell_thickness = []
+        self._cell_belts = []
+        self.total_length = 0.0
+        if sections:
+            pos = 0.0
+            for raw in sections:
+                try:
+                    length = max(0.0, float(raw.get("length", 0.0)))
+                    thickness = float(raw.get("thickness", 0.0))
+                    belt = int(raw.get("belt_index", 0))
+                except Exception:
+                    continue
+                if length <= 0.0:
+                    continue
+                start = pos
+                end = pos + length
+                self.sections.append({
+                    "start": start,
+                    "end": end,
+                    "thickness": thickness,
+                    "belt": belt,
+                })
+                self._cell_starts.append(start)
+                self._cell_ends.append(end)
+                self._cell_thickness.append(thickness)
+                self._cell_belts.append(belt)
+                pos = end
+            self.total_length = pos
+        upper = self.total_length if self.total_length > 0 else 1.0
+        self.ax.set_xlim(0.0, upper)
+        self.reset_segments(draw=False)
+        self._redraw()
+
+    def set_speeds(self, speeds_mps: Sequence[float]) -> None:
+        self.belt_speeds = {idx: max(0.0, float(val)) for idx, val in enumerate(speeds_mps or [])}
+
+    def set_feeding(self, feeding: bool) -> None:
+        self.feeding = bool(feeding)
+
+    def reset_segments(self, *, draw: bool = True) -> None:
+        self.segments = []
+        if draw:
+            self._redraw()
+
+    # Simulation -------------------------------------------------------
+    def tick(self, delta_seconds: float) -> None:
+        if not self.sections or self.total_length <= 0.0:
+            return
+        dt = float(delta_seconds)
+        if dt <= 0.0:
+            return
+        moved: List[dict] = []
+        for seg in self.segments:
+            start = seg["start"]
+            end = seg["end"]
+            start_speed = self._speed_at(start)
+            end_speed = self._speed_at(end)
+            new_start = start + start_speed * dt
+            new_end = end + end_speed * dt
+            if new_end <= 0.0 or new_start >= self.total_length:
+                continue
+            moved.append({
+                "start": max(0.0, new_start),
+                "end": min(self.total_length, new_end),
+            })
+        if self.feeding:
+            entry_speed = self._speed_at(0.0)
+            if entry_speed > 0.0:
+                delta = entry_speed * dt
+                if delta > 0.0:
+                    moved.append({"start": 0.0, "end": min(self.total_length, delta)})
+        self.segments = self._normalize_segments(moved)
+        self._redraw()
+
+    # Helpers ----------------------------------------------------------
+    def _speed_at(self, position: float) -> float:
+        if not self.sections:
+            return 0.0
+        if position <= 0.0:
+            idx = 0
+        elif position >= self.total_length:
+            idx = len(self.sections) - 1
+        else:
+            idx = bisect.bisect_right(self._cell_starts, position) - 1
+            if idx < 0:
+                idx = 0
+        belt = self._cell_belts[idx] if 0 <= idx < len(self._cell_belts) else 0
+        return float(self.belt_speeds.get(belt, 0.0))
+
+    def _normalize_segments(self, segments: Iterable[dict]) -> List[dict]:
+        tol = self._epsilon
+        cleaned: List[dict] = []
+        for seg in segments:
+            try:
+                start = float(seg["start"])
+                end = float(seg["end"])
+            except Exception:
+                continue
+            start = max(0.0, min(start, self.total_length))
+            end = max(0.0, min(end, self.total_length))
+            if end - start <= tol:
+                continue
+            cleaned.append({"start": start, "end": end})
+        if not cleaned:
+            return []
+        cleaned.sort(key=lambda item: item["start"])
+        merged: List[dict] = []
+        for seg in cleaned:
+            if not merged:
+                merged.append(seg)
+                continue
+            last = merged[-1]
+            if seg["start"] <= last["end"] + tol:
+                last["end"] = max(last["end"], seg["end"])
+            else:
+                merged.append(seg)
+        normalized: List[dict] = []
+        for seg in merged:
+            start = seg["start"]
+            end = seg["end"]
+            idx = self._cell_index(start)
+            while start < end - tol and idx < len(self.sections):
+                cell = self.sections[idx]
+                cell_end = cell["end"]
+                part_end = min(end, cell_end)
+                normalized.append({
+                    "start": start,
+                    "end": part_end,
+                    "cell": idx,
+                })
+                start = part_end
+                if start >= end - tol:
+                    break
+                idx += 1
+        if not normalized:
+            return []
+        normalized.sort(key=lambda item: (item["cell"], item["start"]))
+        final: List[dict] = []
+        for seg in normalized:
+            if not final:
+                final.append(seg)
+                continue
+            last = final[-1]
+            if seg["cell"] == last["cell"] and seg["start"] <= last["end"] + tol:
+                last["end"] = max(last["end"], seg["end"])
+            else:
+                final.append(seg)
+        final.sort(key=lambda item: item["start"])
+        return final
+
+    def _cell_index(self, position: float) -> int:
+        if not self.sections:
+            return 0
+        if position <= 0.0:
+            return 0
+        if position >= self.total_length:
+            return len(self.sections) - 1
+        idx = bisect.bisect_right(self._cell_starts, position) - 1
+        if idx < 0:
+            return 0
+        return min(idx, len(self.sections) - 1)
+
+    def _segment_step(self, segment: dict) -> tuple[list[float], list[float]]:
+        tol = self._epsilon
+        start = segment["start"]
+        end = segment["end"]
+        idx = segment.get("cell", self._cell_index(start))
+        x: List[float] = [start]
+        y: List[float] = [0.0]
+        current = start
+        while current < end - tol and idx < len(self.sections):
+            cell = self.sections[idx]
+            cell_end = min(end, cell["end"])
+            height = float(cell["thickness"])
+            x.extend([current, cell_end])
+            y.extend([height, height])
+            current = cell_end
+            if current >= end - tol:
+                break
+            idx += 1
+        x.append(end)
+        y.append(0.0)
+        return x, y
+
+    def _build_plot_arrays(self) -> tuple[list[float], list[float]]:
+        if not self.segments:
+            return [0.0, 0.0], [0.0, 0.0]
+        xs: List[float] = []
+        ys: List[float] = []
+        tol = self._epsilon
+        for seg in self.segments:
+            seg_x, seg_y = self._segment_step(seg)
+            if not seg_x:
+                continue
+            if xs and abs(seg_x[0] - xs[-1]) <= tol and abs(ys[-1]) <= tol:
+                seg_x = seg_x[1:]
+                seg_y = seg_y[1:]
+            xs.extend(seg_x)
+            ys.extend(seg_y)
+        if not xs:
+            return [0.0, 0.0], [0.0, 0.0]
+        return xs, ys
+
+    def _clear_fills(self) -> None:
+        for artist in getattr(self, "_fills", []):
+            try:
+                artist.remove()
+            except Exception:
+                pass
+        self._fills = []
+
+    def _redraw(self) -> None:
+        xs, ys = self._build_plot_arrays()
+        self._line.set_data(xs, ys)
+        self._clear_fills()
+        t = theme()
+        fills: List = []
+        for seg in self.segments:
+            seg_x, seg_y = self._segment_step(seg)
+            if len(seg_x) < 2:
+                continue
+            fill = self.ax.fill_between(
+                seg_x,
+                seg_y,
+                0.0,
+                step="post",
+                color=t.curve_fill,
+                alpha=t.curve_fill_alpha,
+                zorder=2,
+            )
+            fills.append(fill)
+        self._fills = fills
+        self.ax._product_fill = fills[-1] if fills else None
+        self.canvas.draw_idle()
+
+
+__all__ = ["OvenCurveWidget"]


### PR DESCRIPTION
## Summary
- introduce an OvenCurveWidget that keeps the oven geometry, advances occupied segments over time, and renders the live profile with step-post plots
- switch the Tk app to use the new widget, wiring geometry, speed conversions, feed toggles, and incremental ticks into the animation loop

## Testing
- python -m py_compile Main.py rochias_four/*.py rochias_four/ui/*.py

------
https://chatgpt.com/codex/tasks/task_e_68dc138b614c832e8167c60b96132c17